### PR TITLE
add input_shape, output_shape type conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,9 +95,9 @@ io_change(
     onnx_graph: Union[onnx.onnx_ml_pb2.ModelProto, NoneType] = None,
     output_onnx_file_path: Union[str, NoneType] = '',
     input_names: Union[List[str], NoneType] = [],
-    input_shapes: Union[List[str], NoneType] = [],
+    input_shapes: Union[List[Union[int, str]], NoneType] = [],
     output_names: Union[List[str], NoneType] = [],
-    output_shapes: Union[List[str], NoneType] = [],
+    output_shapes: Union[List[Union[int, str]], NoneType] = [],
     non_verbose: Union[bool, NoneType] = False,
 ) -> onnx.onnx_ml_pb2.ModelProto
 
@@ -122,7 +122,7 @@ io_change(
         The order is unspecified, but must match the order specified for input_shapes.
         e.g. ['input.A', 'input.B', 'input.C']
 
-    input_shapes: Optional[List[str]]
+    input_shapes: Optional[List[Union[int, str]]]
         List of input OP shapes. All input OPs of the model must be specified.
         The order is unspecified, but must match the order specified for input_names.
         e.g.
@@ -137,7 +137,7 @@ io_change(
         The order is unspecified, but must match the order specified for output_shapes.
         e.g. ['output.a', 'output.b', 'output.c']
 
-    output_shapes: Optional[List[str]]
+    output_shapes: Optional[List[Union[int, str]]]
         List of input OP shapes. All output OPs of the model must be specified.
         The order is unspecified, but must match the order specified for output_shapes.
         e.g.

--- a/sio4onnx/onnx_input_output_variable_changer.py
+++ b/sio4onnx/onnx_input_output_variable_changer.py
@@ -3,8 +3,9 @@
 import sys
 import onnx
 from onnx.tools import update_model_dims
-from typing import Optional, List
+from typing import Optional, List, Union
 from argparse import ArgumentParser
+from ast import literal_eval
 
 class Color:
     BLACK          = '\033[30m'
@@ -37,9 +38,9 @@ def io_change(
     onnx_graph: Optional[onnx.ModelProto] = None,
     output_onnx_file_path: Optional[str] = '',
     input_names: Optional[List[str]] = [],
-    input_shapes: Optional[List[str]] = [],
+    input_shapes: Optional[List[Union[int, str]]] = [],
     output_names: Optional[List[str]] = [],
-    output_shapes: Optional[List[str]] = [],
+    output_shapes: Optional[List[Union[int, str]]] = [],
     non_verbose: Optional[bool] = False,
 ) -> onnx.ModelProto:
     """
@@ -65,7 +66,7 @@ def io_change(
         The order is unspecified, but must match the order specified for input_shapes.\n\
         e.g. ['input.A', 'input.B', 'input.C']
 
-    input_shapes: Optional[List[str]]
+    input_shapes: Optional[List[Union[int, str]]]
         List of input OP shapes. All input OPs of the model must be specified.\n\
         The order is unspecified, but must match the order specified for input_names.\n\
         e.g.\n\
@@ -80,7 +81,7 @@ def io_change(
         The order is unspecified, but must match the order specified for output_shapes.\n\
         e.g. ['output.a', 'output.b', 'output.c']
 
-    output_shapes: Optional[List[str]]
+    output_shapes: Optional[List[Union[int, str]]]
         List of input OP shapes. All output OPs of the model must be specified.\n\
         The order is unspecified, but must match the order specified for output_shapes.\n\
         e.g.\n\
@@ -273,10 +274,36 @@ def main():
     input_onnx_file_path = args.input_onnx_file_path
     output_onnx_file_path = args.output_onnx_file_path
     input_names = args.input_names
-    input_shapes = args.input_shapes
     output_names = args.output_names
-    output_shapes = args.output_shapes
     non_verbose = args.non_verbose
+
+    input_shapes = []
+    for src in args.input_shapes:
+        input_shape = []
+        for s in src:
+            try:
+                val = literal_eval(s)
+                if isinstance(val, int) and val >= 0:
+                    input_shape.append(val)
+                else:
+                    input_shape.append(s)
+            except:
+                input_shape.append(s)
+        input_shapes.append(input_shape)
+
+    output_shapes = []
+    for src in args.output_shapes:
+        output_shape = []
+        for s in src:
+            try:
+                val = literal_eval(s)
+                if isinstance(val, int) and val >= 0:
+                    output_shape.append(val)
+                else:
+                    output_shape.append(s)
+            except:
+                output_shape.append(s)
+        output_shapes.append(output_shape)
 
     input_name_list = [name for name in input_names]
     input_shape_list = [name for name in input_shapes]


### PR DESCRIPTION
The arguments `input_dims` and `output_dims` of `onnx.tool.update_inputs_outputs_dims` must be specified in `int` or `str` type.
However command line arguments `input_shape` and `output_shape` of `sio4onnx`  are received in 'str' type.

I added `input_shape` and `output_shape` type convesion.