### PR TITLE
Added the ability to create a new Dimension and overwrite it when `TensorShapeProto.RepeatedCompositeFieldContainer[Dimension]` is `[]`

### DIFF
--- a/sio4onnx/__init__.py
+++ b/sio4onnx/__init__.py
@@ -1,3 +1,3 @@
 from sio4onnx.onnx_input_output_variable_changer import io_change, main
 
-__version__ = '1.0.2'
+__version__ = '1.0.3'


### PR DESCRIPTION
- Added the ability to create a new Dimension and overwrite it when `TensorShapeProto.RepeatedCompositeFieldContainer[Dimension]` is `[]`
- `onnx.tools.update_model_dims()` has a bug so it is no longer available